### PR TITLE
Fix Python 3.12 valid escape warning

### DIFF
--- a/core/prompts.py
+++ b/core/prompts.py
@@ -10,7 +10,7 @@ config.read('configuration.ini')
 interface = config.get('Settings', 'WiFiInterface')    
 
 def print_banner():
-       return ("""
+       return (r"""
                 __             _                            
     ____  ___  / /__________  (_)___  ____  ____ _____ ____ 
    / __ \/ _ \/ __/ ___/ __ \/ / __ \/ __ \/ __ `/ __ `/ _ \\


### PR DESCRIPTION
@ANG13T can you give a quick look and merge it in order to fix valid escape warning on Python 3.12?